### PR TITLE
Make API_HOST an optional arg in datadog init

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ DATADOG = {
   'ENABLED': True,
   'API_KEY': 'xxxx',
   'APP_KEY': 'xxxx',
+  'API_HOST': 'xxxx',
 }
 
 STATSD_HOST = 'localhost'

--- a/django_datadog/tests.py
+++ b/django_datadog/tests.py
@@ -15,7 +15,8 @@ from django_datadog.compat import create_event, create_gauge
 NOT_CONFIGURED = {'DATADOG': {'ENABLED': False}}
 CONFIGURED = {'DATADOG': {'ENABLED': True,
                           'API_KEY': 'test',
-                          'APP_KEY': 'test'},
+                          'APP_KEY': 'test',
+                          'API_HOST': 'test',},
               'STATSD_HOST': 'localhost',
               'STATSD_PORT': '12334'}
 

--- a/django_datadog/utils.py
+++ b/django_datadog/utils.py
@@ -9,10 +9,21 @@ def init_datadog():
     :returns: bool
     """
     if settings.DATADOG['ENABLED']:
-        initialize(statsd_host=settings.STATSD_HOST,
-                   statsd_port=settings.STATSD_PORT,
-                   api_key=settings.DATADOG['API_KEY'],
-                   app_key=settings.DATADOG['APP_KEY'])
+        # Prepare the parameters for the initialize function
+        init_params = {
+            'statsd_host': settings.STATSD_HOST,
+            'statsd_port': settings.STATSD_PORT,
+            'api_key': settings.DATADOG['API_KEY'],
+            'app_key': settings.DATADOG['APP_KEY']
+        }
+
+        # Add api_host to the parameters if it's provided
+        if 'API_HOST' in settings.DATADOG:
+            init_params['api_host'] = settings.DATADOG['API_HOST']
+
+        # Initialize DataDog with the provided parameters
+        initialize(**init_params)
+
         return True
 
     return False


### PR DESCRIPTION
Make API_HOST configurable, so different datadog sites are usable.

Set by initialize module here - https://github.com/DataDog/datadogpy/blob/4dcf1ed41724ce51ae31bbf14e488cfc0c49772a/datadog/__init__.py#L112